### PR TITLE
Add task closure modal with file attachments

### DIFF
--- a/app.css
+++ b/app.css
@@ -132,3 +132,8 @@
          vertical-align: top;
     }
 
+    /* Archivos adjuntos */
+    #lista-archivos { margin: 10px 0; list-style: none; padding: 0; }
+    #lista-archivos li { margin-bottom: 4px; font-size: 14px; }
+    .descarga-btn{background:#28a745;color:#fff;border:none;padding:5px 10px;border-radius:4px;cursor:pointer;margin-right:4px;}
+

--- a/app.js
+++ b/app.js
@@ -57,26 +57,46 @@
   byId('volver').onclick=()=>seleccionarVista('contactos');
   byId('agregar-tarea').onclick=()=>{byId('form-tarea').reset();byId('t-id').value='';abrirModal('modal-tarea');};
   byId('form-tarea').addEventListener('submit',e=>{e.preventDefault();const id=byId('t-id').value;const obj={desc:byId('t-desc').value,lugar:byId('t-lugar').value,fecha:byId('t-fecha').value,hora:byId('t-hora').value,notas:byId('t-notas').value,contactoId:state.contactoActual,estado:'pendiente'};if(id){const idx=state.tareas.findIndex(t=>t.id==id);state.tareas[idx]={...state.tareas[idx],...obj};}else{obj.id=Date.now();state.tareas.push(obj);}guardar();cerrarModal('modal-tarea');renderDetalle();});byId('guardar-nota').addEventListener('click',()=>{const nota=byId('nota-seguimiento').value;if(!nota)return;const contacto=state.contactos.find(c=>c.id===state.contactoActual);if(!contacto)return;if(!contacto.seguimiento)contacto.seguimiento=[];contacto.seguimiento.push({fecha:new Date().toISOString(),nota:nota});guardar();renderDetalle();byId('nota-seguimiento').value='';});function renderDetalle(){const c=state.contactos.find(c=>c.id===state.contactoActual);if(!c)return;byId('nombre-detalle').textContent='Seguimiento: '+c.nombre;byId('info-contacto').innerHTML=`<p><strong>Tipo:</strong> ${c.tipo}</p><p><strong>Empresa:</strong> ${c.comercial||'—'}</p><p><strong>Razón Social:</strong> ${c.razon||'—'}</p><p><strong>Email:</strong> ${c.email||'—'}</p><p><strong>Teléfono:</strong> ${c.telefono||'—'}</p><p><strong>Ubicación:</strong> ${c.ubicacion||'—'}</p><p><strong>Quién recomienda:</strong> ${c.refiere||'—'}</p><p><strong>Vendedor/Agente:</strong> ${c.agente||'—'}</p><p><strong>Tipo de Empresa:</strong> ${c.empresa||'—'}</p>`;/* tareas pendientes */const tbodyPendientes=byId('tabla-tareas-pendientes');tbodyPendientes.innerHTML='';state.tareas.filter(t=>t.contactoId===c.id&&t.estado==='pendiente').forEach(t=>{const tr=document.createElement('tr');tr.innerHTML=`<td>${t.desc}</td><td>${t.lugar||''}</td><td>${formatoFecha(t.fecha)} ${t.hora}</td><td>${t.notas||''}</td><td><button class='accion' data-fin='${t.id}'>✓</button></td>`;tbodyPendientes.appendChild(tr);});/* historial */const tbH=byId('tabla-historial');tbH.innerHTML='';const historialOrdenado=(c.seguimiento||[]).sort((a,b)=>new Date(b.fecha)-new Date(a.fecha));historialOrdenado.forEach(fu=>{const tr=document.createElement('tr');tr.innerHTML=`<td>Nota de seguimiento</td><td>${new Date(fu.fecha).toLocaleString()}</td><td>N/A</td><td>${fu.nota||''}</td>`;tbH.appendChild(tr);});renderHistorialTareas();}
-  // Se corrige el selector para que coincida con el ID presente en el HTML
-  byId('tabla-tareas-pendientes').addEventListener('click',e=>{
-    if(e.target.dataset.fin){
-      const id=parseInt(e.target.dataset.fin);
-      const t=state.tareas.find(x=>x.id===id);
-      t.estado='finalizada';
-      t.duracion=prompt('Duración (ej. 5Min):','');
-      t.comentario=prompt('Comentario:','');
-      guardar();
-      renderDetalle();
-    }
-  });
-  function renderHistorialTareas(){
+  let cierreId=null;
+byId("tabla-tareas-pendientes").addEventListener("click",e=>{
+  if(e.target.dataset.fin){
+    cierreId=parseInt(e.target.dataset.fin);
+    byId("form-cierre").reset();
+    byId("lista-archivos").innerHTML="";
+    abrirModal("modal-cierre");
+  }
+});
+byId("f-archivos").addEventListener("change",()=>{
+  const ul=byId("lista-archivos");
+  ul.innerHTML="";
+  [...byId("f-archivos").files].forEach(f=>{const li=document.createElement("li");li.textContent=f.name;ul.appendChild(li);});
+});
+byId("form-cierre").addEventListener("submit",async e=>{
+  e.preventDefault();
+  const t=state.tareas.find(x=>x.id===cierreId);
+  if(!t) return;
+  t.estado="finalizada";
+  t.duracion=byId("f-duracion").value;
+  t.comentario=byId("f-comentario").value;
+  const files=[...byId("f-archivos").files];
+  if(files.length){
+    t.archivos=await Promise.all(files.map(file=>new Promise(res=>{const r=new FileReader();r.onload=()=>res({name:file.name,data:r.result});r.readAsDataURL(file);})));
+  }else{
+    t.archivos=[];
+  }
+  guardar();
+  cerrarModal("modal-cierre");
+  renderDetalle();
+});
+function renderHistorialTareas(){
     const tbody=byId('tabla-historial-tareas');
     if(!tbody) return;
     tbody.innerHTML='';
     const tareasFinalizadas=state.tareas.filter(t=>t.contactoId===state.contactoActual && t.estado==='finalizada').sort((a,b)=>new Date(b.fecha)-new Date(a.fecha));
     tareasFinalizadas.forEach(t=>{
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${t.desc}</td><td>${t.lugar||''}</td><td>${formatoFecha(t.fecha)} ${t.hora||''}</td><td>${t.duracion||''}</td><td>${t.comentario||''}</td>`;
+      const archivos=(t.archivos||[]).map(a=>`<a class='descarga-btn' href="${a.data}" download="${a.name}">Descargar</a>`).join(' ');
+      tr.innerHTML=`<td>${t.desc}</td><td>${t.lugar||''}</td><td>${formatoFecha(t.fecha)} ${t.hora||''}</td><td>${t.duracion||''}</td><td>${t.comentario||''}</td><td>${archivos}</td>`;
       tbody.appendChild(tr);
     });
   }

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
  <div class="seguimiento-section" style="margin-top: 24px;">
  <h3>Historial de tareas</h3>
  <div class="tabla-contenedor">
- <table><thead><tr><th>Tarea</th><th>Lugar</th><th>Fecha/Hora</th><th>Duración</th><th>Comentario</th></tr></thead><tbody id="tabla-historial-tareas"></tbody></table>
+ <table><thead><tr><th>Tarea</th><th>Lugar</th><th>Fecha/Hora</th><th>Duración</th><th>Comentario</th><th>Archivos</th></tr></thead><tbody id="tabla-historial-tareas"></tbody></table>
  </div>
  </div>
 
@@ -144,7 +144,22 @@
       <div class="campo"><label>Lugar/Ubicación</label><input id="t-lugar"></div>
       <div class="campo" style="display:flex;gap:8px"><div style="flex:1"><label>Fecha</label><input id="t-fecha" type="date" required></div><div style="flex:1"><label>Hora</label><input id="t-hora" type="time" required></div></div>
       <div class="campo"><label>Observaciones</label><textarea id="t-notas"></textarea></div>
-      <button class="btn" type="submit">Guardar tarea</button>
+    <button class="btn" type="submit">Guardar tarea</button>
+    </form>
+  </div></div>
+  <!-- MODAL CIERRE TAREA -->
+  <div id="modal-cierre" class="modal"><div class="modal-contenido">
+    <span class="cerrar" data-cerrar="modal-cierre">&times;</span>
+    <div class="modal-header">
+      <h3>Cerrar tarea</h3>
+    </div>
+    <form id="form-cierre">
+      <input type="hidden" id="f-id">
+      <div class="campo"><label>Duración</label><input id="f-duracion" required></div>
+      <div class="campo"><label>Comentario</label><textarea id="f-comentario"></textarea></div>
+      <div class="campo"><label>Archivos</label><input id="f-archivos" type="file" multiple></div>
+      <ul id="lista-archivos"></ul>
+      <button class="btn" type="submit">Guardar</button>
     </form>
   </div></div>
   <!-- MODAL DIA CALENDARIO -->


### PR DESCRIPTION
## Summary
- add new column for attachments in task history table
- add modal to finalize tasks with duration, comment, and file uploads
- handle closing tasks using modal in JS and show downloadable links
- basic styles for attachments and download button

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686ff9ae1b748320bec2220fa27ecb0d