### PR TITLE
Add file attachments to closed tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           <div class="tabla-contenedor">
             <table>
               <thead>
-                <tr><th>Tarea</th><th>Lugar</th><th>Fecha/Hora</th><th>Duración</th><th>Comentario</th></tr>
+                <tr><th>Tarea</th><th>Lugar</th><th>Fecha/Hora</th><th>Duración</th><th>Comentario</th><th>Archivos</th></tr>
               </thead>
               <tbody id="tabla-historial-tareas"></tbody>
             </table>
@@ -191,6 +191,21 @@
       <span class="cerrar" data-cerrar="modal-dia">&times;</span>
       <div class="modal-header"><h3 id="titulo-dia"></h3></div>
       <ul id="lista-dia"></ul>
+    </div>
+  </div>
+
+  <!-- MODAL FIN TAREA -->
+  <div id="modal-fin-tarea" class="modal">
+    <div class="modal-contenido">
+      <span class="cerrar" data-cerrar="modal-fin-tarea">&times;</span>
+      <div class="modal-header"><h3>Cerrar tarea</h3></div>
+      <form id="form-fin-tarea">
+        <input type="hidden" id="fin-id">
+        <div class="campo"><label>Duración</label><input id="fin-duracion" placeholder="Ej. 5Min"></div>
+        <div class="campo"><label>Comentario</label><textarea id="fin-comentario"></textarea></div>
+        <div class="campo"><label>Adjuntar archivos</label><input id="fin-archivos" type="file" multiple></div>
+        <button class="btn" type="submit">Guardar</button>
+      </form>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,7 @@
     th,td{padding:13px;border-bottom:1px solid #dee2e6;text-align:left;font-size:14px}
     th{background:var(--gris-claro);font-weight:600}
     tbody tr:hover{background:#e9efff;cursor:pointer}
-    .accion{background:#dc3545;color:#fff;border:none;padding:5px 10px;border-radius:4px;cursor:pointer}
+    .accion{background:#dc3545;color:#fff;border:none;padding:5px 10px;border-radius:4px;cursor:pointer;text-decoration:none;display:inline-block}
     /* calendario */
     #calendario-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:5px}
     .dia-enc,.dia{padding:8px;text-align:center}


### PR DESCRIPTION
## Summary
- allow attachments on completed tasks
- show a modal to close tasks with duration, comment, and files
- display download links for attached files
- tweak action button style

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687000c3b0388320b99362adcb0d12ea