### PR TITLE
Add task closing in calendar day modal

### DIFF
--- a/app.css
+++ b/app.css
@@ -135,5 +135,10 @@
     /* Archivos adjuntos */
     #lista-archivos { margin: 10px 0; list-style: none; padding: 0; }
     #lista-archivos li { margin-bottom: 4px; font-size: 14px; }
-    .descarga-btn{background:#28a745;color:#fff;border:none;padding:5px 10px;border-radius:4px;cursor:pointer;margin-right:4px;}
+.descarga-btn{background:#28a745;color:#fff;border:none;padding:5px 10px;border-radius:4px;cursor:pointer;margin-right:4px;}
+
+/* Lista de tareas del día en el calendario */
+#lista-dia{list-style:none;padding:0;margin:0;}
+#lista-dia li{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;border-bottom:1px solid #eee;}
+#lista-dia li:last-child{border-bottom:none;}
 


### PR DESCRIPTION
## Summary
- allow closing tasks from day modal
- style tasks list in day modal
- refresh calendar/day view when closing tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68700888eb1483209f7c1e5a7f0de81f