### PR TITLE
Add task state coloring in calendar

### DIFF
--- a/app.css
+++ b/app.css
@@ -49,7 +49,11 @@
     .dia-enc{font-weight:700;color:var(--gris)}
     .dia{background:var(--blanco);min-height:90px;position:relative;border:1px solid #eee}
     .numero{position:absolute;top:4px;right:6px;font-size:12px}
-    .tarea-badge{background:var(--azul);color:#fff;font-size:11px;padding:1px 4px;border-radius:3px;display:inline-block;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.tarea-badge{background:var(--azul);color:#fff;font-size:11px;padding:1px 4px;border-radius:3px;display:inline-block;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+/* Colores para tareas según estado */
+.tarea-pasada{background:#dc3545;color:#fff}
+.tarea-hoy{background:#ffc107;color:#000}
+.tarea-cerrada{background:#28a745;color:#fff}
     .dia:hover{background:#e9efff;cursor:pointer}
     /* modal */
     .modal{display:none;position:fixed;z-index:1000;left:0;top:0;width:100%;height:100%;background:rgba(0,0,0,.6);justify-content:center;align-items:center}
@@ -140,5 +144,8 @@
 /* Lista de tareas del día en el calendario */
 #lista-dia{list-style:none;padding:0;margin:0;}
 #lista-dia li{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;border-bottom:1px solid #eee;}
+#lista-dia li.tarea-pasada{background:#f8d7da;border-left:4px solid #dc3545;}
+#lista-dia li.tarea-hoy{background:#fff3cd;border-left:4px solid #ffc107;}
+#lista-dia li.tarea-cerrada{background:#d4edda;border-left:4px solid #28a745;}
 #lista-dia li:last-child{border-bottom:none;}
 

--- a/app.js
+++ b/app.js
@@ -110,16 +110,25 @@ function renderHistorialTareas(){
   byId('mes-prev').onclick=()=>{state.fechaCalendario.setMonth(state.fechaCalendario.getMonth()-1);renderCalendario();};
   byId('mes-next').onclick=()=>{state.fechaCalendario.setMonth(state.fechaCalendario.getMonth()+1);renderCalendario();};
   function renderCalendario(){const grid=byId('calendario-grid');grid.innerHTML='';const f=new Date(state.fechaCalendario.getFullYear(),state.fechaCalendario.getMonth(),1);const year=f.getFullYear(),mes=f.getMonth();byId('titulo-mes').textContent=f.toLocaleString('es-ES',{month:'long',year:'numeric'});const primerDia=f.getDay();const diasMes=new Date(year,mes+1,0).getDate();for(let i=0;i<primerDia;i++){grid.appendChild(document.createElement('div'));}
-    for(let d=1;d<=diasMes;d++){const cel=document.createElement('div');cel.className='dia';cel.innerHTML=`<span class='numero'>${d}</span>`;const fechaStr=`${year}-${String(mes+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;const lista=state.tareas.filter(t=>t.fecha===fechaStr);lista.forEach(t=>{const badge=document.createElement('div');badge.className='tarea-badge';const contacto=state.contactos.find(c=>c.id===t.contactoId);badge.textContent=t.desc+(contacto?` (${contacto.nombre})`:"");cel.appendChild(badge);});cel.onclick=()=>mostrarDia(fechaStr);grid.appendChild(cel);} }
+    const hoy=new Date().toISOString().slice(0,10);
+    for(let d=1;d<=diasMes;d++){const cel=document.createElement('div');cel.className='dia';cel.innerHTML=`<span class='numero'>${d}</span>`;const fechaStr=`${year}-${String(mes+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;const lista=state.tareas.filter(t=>t.fecha===fechaStr);lista.forEach(t=>{const badge=document.createElement('div');badge.className='tarea-badge';const contacto=state.contactos.find(c=>c.id===t.contactoId);badge.textContent=t.desc+(contacto?` (${contacto.nombre})`:"");if(t.estado==='finalizada'){badge.classList.add('tarea-cerrada');}else if(t.fecha<hoy){badge.classList.add('tarea-pasada');}else if(t.fecha===hoy){badge.classList.add('tarea-hoy');}cel.appendChild(badge);});cel.onclick=()=>mostrarDia(fechaStr);grid.appendChild(cel);} }
   function mostrarDia(fecha){
     fechaDiaActual=fecha;
     byId('titulo-dia').textContent='Tareas del '+formatoFecha(fecha);
     const ul=byId('lista-dia');
     ul.innerHTML='';
+    const hoy=new Date().toISOString().slice(0,10);
     state.tareas.filter(t=>t.fecha===fecha).forEach(t=>{
       const li=document.createElement('li');
       const contacto=state.contactos.find(c=>c.id===t.contactoId)||{};
       li.innerHTML=`<span>${t.desc} - ${contacto.nombre||''} ${t.hora||''}</span>`;
+      if(t.estado==='finalizada'){
+        li.classList.add('tarea-cerrada');
+      }else if(t.fecha<hoy){
+        li.classList.add('tarea-pasada');
+      }else if(t.fecha===hoy){
+        li.classList.add('tarea-hoy');
+      }
       if(t.estado!=='finalizada'){
         const btn=document.createElement('button');
         btn.textContent='Cerrar';


### PR DESCRIPTION
## Summary
- highlight tasks with red/yellow/green colors based on state
- apply the same coloring to the day modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870202820508320bda371d06c1d038e