### PR TITLE
Add task coloring by status

### DIFF
--- a/app.css
+++ b/app.css
@@ -141,4 +141,11 @@
 #lista-dia{list-style:none;padding:0;margin:0;}
 #lista-dia li{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;border-bottom:1px solid #eee;}
 #lista-dia li:last-child{border-bottom:none;}
+/* Colores de estado para tareas */
+.tarea-verde{background:#d4edda;color:#155724;}
+.tarea-amarilla{background:#fff3cd;color:#856404;}
+.tarea-roja{background:#f8d7da;color:#721c24;}
+.tarea-badge.verde{background:#28a745;}
+.tarea-badge.amarilla{background:#ffc107;color:#000;}
+.tarea-badge.roja{background:#dc3545;}
 


### PR DESCRIPTION
## Summary
- add CSS classes for task state colors
- compute task state class in JS
- color badges and day modal items according to task status

## Testing
- `node -e "require('./app.js');"` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6870202820508320bda371d06c1d038e