### PR TITLE
Add closing tasks from calendar day modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,6 +249,16 @@
     }
   });
 
+  $('lista-dia').addEventListener('click', e => {
+    if (e.target.dataset.fin) {
+      const id = parseInt(e.target.dataset.fin);
+      $('form-fin-tarea').reset();
+      $('fin-id').value = id;
+      closeModal('modal-dia');
+      openModal('modal-fin-tarea');
+    }
+  });
+
   $('form-fin-tarea').addEventListener('submit', async e => {
     e.preventDefault();
     const id = parseInt($('fin-id').value);
@@ -316,7 +326,14 @@
     state.tareas.filter(t => t.fecha === fecha).forEach(t => {
       const li = document.createElement('li');
       const contacto = state.contactos.find(c => c.id === t.contactoId) || {};
-      li.textContent = `${t.desc} - ${contacto.nombre || ''} ${t.hora}`;
+      li.innerHTML = `<span>${t.desc} - ${contacto.nombre || ''} ${t.hora}</span>`;
+      if (t.estado === 'pendiente') {
+        const btn = document.createElement('button');
+        btn.className = 'accion';
+        btn.dataset.fin = t.id;
+        btn.textContent = 'Cerrar';
+        li.appendChild(btn);
+      }
       ul.appendChild(li);
     });
     openModal('modal-dia');

--- a/styles.css
+++ b/styles.css
@@ -132,4 +132,9 @@
          vertical-align: top;
     }
 
+    /* Dia modal task list */
+    #lista-dia{list-style:none;padding:0;margin:0}
+    #lista-dia li{display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #dee2e6}
+    #lista-dia li:last-child{border-bottom:none}
+
   


### PR DESCRIPTION
## Summary
- enable closing tasks directly from the day modal
- show 'Cerrar' buttons only for pending tasks
- improve day modal list layout

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68701fadaa788320951090cf5174bd28