### PR TITLE
Enable task creation from day modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,8 +72,55 @@ function seleccionarVista(v){
   byId('tabla-contactos').addEventListener('click',e=>{const tr=e.target.closest('tr');if(!tr)return;const id=parseInt(tr.dataset.id);if(e.target.dataset.del){if(confirm('¿Eliminar contacto?')){state.contactos=state.contactos.filter(c=>c.id!==id);state.tareas=state.tareas.filter(t=>t.contactoId!==id);guardar();renderContactos();}}else{state.contactoActual=id;seleccionarVista('detalle');}});
   /* ========= DETALLE CONTACTO Y TAREAS ========= */
   byId('volver').onclick=()=>seleccionarVista('contactos');
-  byId('agregar-tarea').onclick=()=>{byId('form-tarea').reset();byId('t-id').value='';abrirModal('modal-tarea');};
-  byId('form-tarea').addEventListener('submit',e=>{e.preventDefault();const id=byId('t-id').value;const obj={desc:byId('t-desc').value,lugar:byId('t-lugar').value,fecha:byId('t-fecha').value,hora:byId('t-hora').value,notas:byId('t-notas').value,contactoId:state.contactoActual,estado:'pendiente'};if(id){const idx=state.tareas.findIndex(t=>t.id==id);state.tareas[idx]={...state.tareas[idx],...obj};}else{obj.id=Date.now();state.tareas.push(obj);}guardar();cerrarModal('modal-tarea');renderDetalle();});byId('guardar-nota').addEventListener('click',()=>{const nota=byId('nota-seguimiento').value;if(!nota)return;const contacto=state.contactos.find(c=>c.id===state.contactoActual);if(!contacto)return;if(!contacto.seguimiento)contacto.seguimiento=[];contacto.seguimiento.push({fecha:new Date().toISOString(),nota:nota});guardar();renderDetalle();byId('nota-seguimiento').value='';});function renderDetalle(){const c=state.contactos.find(c=>c.id===state.contactoActual);if(!c)return;byId('nombre-detalle').textContent='Seguimiento: '+c.nombre;byId('info-contacto').innerHTML=`<p><strong>Tipo:</strong> ${c.tipo}</p><p><strong>Empresa:</strong> ${c.comercial||'—'}</p><p><strong>Razón Social:</strong> ${c.razon||'—'}</p><p><strong>Email:</strong> ${c.email||'—'}</p><p><strong>Teléfono:</strong> ${c.telefono||'—'}</p><p><strong>Ubicación:</strong> ${c.ubicacion||'—'}</p><p><strong>Quién recomienda:</strong> ${c.refiere||'—'}</p><p><strong>Vendedor / Agente:</strong> ${c.agente||'—'}</p><p><strong>Tipo de Empresa:</strong> ${c.empresa||'—'}</p>`;/* tareas pendientes */const tbodyPendientes=byId('tabla-tareas-pendientes');tbodyPendientes.innerHTML='';state.tareas.filter(t=>t.contactoId===c.id&&t.estado==='pendiente').forEach(t=>{const tr=document.createElement('tr');tr.innerHTML=`<td>${t.desc}</td><td>${t.lugar||''}</td><td>${formatoFecha(t.fecha)} ${t.hora}</td><td>${t.notas||''}</td><td><button class='accion' data-fin='${t.id}'>✓</button></td>`;tbodyPendientes.appendChild(tr);});/* historial */const tbH=byId('tabla-historial');tbH.innerHTML='';const historialOrdenado=(c.seguimiento||[]).sort((a,b)=>new Date(b.fecha)-new Date(a.fecha));historialOrdenado.forEach(fu=>{const tr=document.createElement('tr');tr.innerHTML=`<td>Nota de seguimiento</td><td>${new Date(fu.fecha).toLocaleString()}</td><td>N/A</td><td>${fu.nota||''}</td>`;tbH.appendChild(tr);});renderHistorialTareas();}
+  function llenarSelectContactos(sel){
+    sel.innerHTML=state.contactos.map(c=>`<option value="${c.id}">${c.nombre}</option>`).join('');
+  }
+
+  function abrirModalTarea({contactoId=null,fecha=null}={}){
+    byId('form-tarea').reset();
+    byId('t-id').value='';
+    const sel=byId('t-contacto');
+    if(sel){
+      llenarSelectContactos(sel);
+      if(contactoId){
+        sel.value=contactoId;
+        sel.disabled=true;
+      }else{
+        sel.disabled=false;
+      }
+    }
+    if(fecha) byId('t-fecha').value=fecha;
+    abrirModal('modal-tarea');
+  }
+
+  byId('agregar-tarea').onclick=()=>abrirModalTarea({contactoId:state.contactoActual});
+byId('form-tarea').addEventListener('submit',e=>{
+  e.preventDefault();
+  const id=byId('t-id').value;
+  const sel=byId('t-contacto');
+  const contactoId=sel?parseInt(sel.value):state.contactoActual;
+  const obj={
+    desc:byId('t-desc').value,
+    lugar:byId('t-lugar').value,
+    fecha:byId('t-fecha').value,
+    hora:byId('t-hora').value,
+    notas:byId('t-notas').value,
+    contactoId,
+    estado:'pendiente'
+  };
+  if(id){
+    const idx=state.tareas.findIndex(t=>t.id==id);
+    state.tareas[idx]={...state.tareas[idx],...obj};
+  }else{
+    obj.id=Date.now();
+    state.tareas.push(obj);
+  }
+  guardar();
+  cerrarModal('modal-tarea');
+  renderDetalle();
+  renderCalendario();
+  if(fechaDiaActual) mostrarDia(fechaDiaActual);
+});
 let cierreId=null;
 let fechaDiaActual=null;
 byId("tabla-tareas-pendientes").addEventListener("click",e=>{
@@ -319,7 +366,7 @@ byId("form-cierre").addEventListener("submit",async e=>{
       }
       ul.appendChild(li);
     });
-    abrirModal('modal-dia');
+  abrirModal('modal-dia');
   }
 
   byId('lista-dia').addEventListener('click',e=>{
@@ -331,6 +378,7 @@ byId("form-cierre").addEventListener("submit",async e=>{
       abrirModal('modal-cierre');
     }
   });
+  byId('nueva-tarea-dia').onclick=()=>abrirModalTarea({fecha:fechaDiaActual});
   /* ========= MODALES GENÉRICOS ========= */
   document.querySelectorAll('[data-cerrar]').forEach(el=>el.onclick=()=>cerrarModal(el.dataset.cerrar));
   document.querySelectorAll('.modal').forEach(m=>m.addEventListener('click',e=>{if(e.target===m)cerrarModal(m.id);}));

--- a/index.html
+++ b/index.html
@@ -181,6 +181,7 @@
     </div>
     <form id="form-tarea">
       <input type="hidden" id="t-id">
+      <div class="campo"><label>Contacto</label><select id="t-contacto"></select></div>
       <div class="campo"><label>Descripción de la tarea</label><input id="t-desc" required></div>
       <div class="campo"><label>Lugar/Ubicación</label><input id="t-lugar"></div>
       <div class="campo" style="display:flex;gap:8px"><div style="flex:1"><label>Fecha</label><input id="t-fecha" type="date" required></div><div style="flex:1"><label>Hora</label><input id="t-hora" type="time" required></div></div>
@@ -209,6 +210,7 @@
     <div class="modal-header">
       <h3 id="titulo-dia"></h3>
     </div>
+    <button id="nueva-tarea-dia" class="btn" type="button">Nueva tarea</button>
     <ul id="lista-dia"></ul>
   </div></div>
 


### PR DESCRIPTION
## Summary
- add contact selector in the task modal
- allow creating a task from calendar day modal
- populate contact dropdown depending on context

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870464f58f48320b86c1d20b0726636