### PR TITLE
Make day modal tasks link to contact

### DIFF
--- a/app.js
+++ b/app.js
@@ -322,6 +322,7 @@ byId("form-cierre").addEventListener("submit",async e=>{
     const filtro=filtroSel?filtroSel.value:'todos';
     state.tareas.filter(t=>t.fecha===fecha && (filtro==='todos'||t.contactoId==filtro)).forEach(t=>{
       const li=document.createElement('li');
+      li.dataset.contacto = t.contactoId;
       const contacto=state.contactos.find(c=>c.id===t.contactoId)||{};
       li.innerHTML=`<span>${t.desc} - ${contacto.nombre||''} ${t.hora||''}</span>`;
       const cls=claseEstado(t);
@@ -345,6 +346,13 @@ byId("form-cierre").addEventListener("submit",async e=>{
       byId('lista-archivos').innerHTML='';
       cerrarModal('modal-dia');
       abrirModal('modal-cierre');
+    } else {
+      const li=e.target.closest('li');
+      if(li && li.dataset.contacto){
+        state.contactoActual=parseInt(li.dataset.contacto);
+        cerrarModal('modal-dia');
+        seleccionarVista('detalle');
+      }
     }
   });
   byId('dia-nueva-tarea').onclick=()=>abrirModalTarea(null, fechaDiaActual);


### PR DESCRIPTION
## Summary
- store contact id in day modal list items
- support navigation to contact detail when clicking a task in the day modal

## Testing
- `node -e "require('./app.js')"` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68713411f8d88320a430f2bac941c7ef